### PR TITLE
accept any input instead of a static tiddler's text field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "url": "https://thaddeusjiang.github.io/tw5-vega-lite",
   "license": "MIT",
-  "version": "0.0.1",
+  "version": "0.0.2-prerelease",
   "scripts": {
     "reset": "rimraf ./**/node_modules",
     "clean": "rimraf dist",

--- a/src/vega-lite/VegaLiteWidget.ts
+++ b/src/vega-lite/VegaLiteWidget.ts
@@ -21,8 +21,7 @@ class VegaLiteWidget extends Widget {
     containerElement.setAttribute('id', id);
     this.domNodes.push(parent.appendChild(containerElement));
 
-    const tid = this.getAttribute('spec', '');
-    const spec = JSON.parse(this.wiki.getTiddler(tid)?.fields?.text);
+    const spec = JSON.parse(this.getAttribute('spec', ''));
 
     const theme: any = this.getAttribute('theme', 'quartz');
 

--- a/src/vega-lite/VegaLiteWidget.ts
+++ b/src/vega-lite/VegaLiteWidget.ts
@@ -21,11 +21,13 @@ class VegaLiteWidget extends Widget {
     containerElement.setAttribute('id', id);
     this.domNodes.push(parent.appendChild(containerElement));
 
-    const spec = JSON.parse(this.getAttribute('spec', ''));
-
     const theme: any = this.getAttribute('theme', 'quartz');
-
-    vegaEmbed(`#${id}`, spec, { theme }).catch(console.error);
+    try {
+      const spec = JSON.parse(this.getAttribute('spec', ''));
+      vegaEmbed(`#${id}`, spec, { theme }).catch(console.error);
+    } catch(e) {
+      console.error(e);
+    }
   }
 }
 

--- a/src/vega-lite/plugin.info
+++ b/src/vega-lite/plugin.info
@@ -4,6 +4,6 @@
   "author": "ThaddeusJiang",
   "description": "vega-lite in TiddlyWiki",
   "plugin-type": "plugin",
-  "version": "0.0.1",
+  "version": "0.0.2-prerelease",
   "list": ["readme"]
 }

--- a/src/vega-lite/readme.tid
+++ b/src/vega-lite/readme.tid
@@ -23,12 +23,12 @@ Drag and drop the following tiddlers into your wiki: <<tag $:/plugins/ThaddeusJi
 !!! 2. widget
 
 ```wikitext
-<$vega-lite spec="seattle-weather.json" />
+<$vega-lite spec={{seattle-weather.json}} />
 ```
 
 !!! 3. result
 
-<$vega-lite spec="seattle-weather.json" />
+<$vega-lite spec={{seattle-weather.json}} />
 
 !! Links
 


### PR DESCRIPTION
this would allow to eg. build some JSON programmatically eg. in TW5 wikitext before it is fed to Vega

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support passing Vega-Lite specs directly via the spec attribute (JSON or moustache-interpolated tiddler content).

- Bug Fixes / Stability
  - Improved error handling when parsing and embedding Vega-Lite specs to reduce failures and log invalid JSON.

- Documentation
  - Updated usage examples to show spec={{...}} for dynamic tiddler-based specs; minor EOF newline fix.

- Chores
  - Bumped app and plugin versions to 0.0.2-prerelease.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->